### PR TITLE
Slight typo in import js example 🕷

### DIFF
--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -29,7 +29,7 @@ export default () => {
 ```javascript
 /* globals jQuery */
 
-import toggle from './components/atoms/toggle/toggle.js';
+import toggle from './atoms/toggle/toggle.js';
 
 const init = () => {
   toggle();


### PR DESCRIPTION
Since the base.js is in `components`, the relative link should not include `components`